### PR TITLE
feat: add ListenBrainz integration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ dependencies = [
     "rich>=13.0",
     "spotipy>=2.23",
     "aiofiles>=23.2",
+    "musicbrainzngs>=0.7",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ dependencies = [
     "spotipy>=2.23",
     "aiofiles>=23.2",
     "musicbrainzngs>=0.7",
+    "httpx>=0.27",
 ]
 
 [project.optional-dependencies]

--- a/src/musinsights/analyzers/__init__.py
+++ b/src/musinsights/analyzers/__init__.py
@@ -1,7 +1,7 @@
 """Audio analyzers for extracting features from songs."""
 
-from musinsights.analyzers.base import AnalysisResult, BaseAnalyzer, SongFeatures
 from musinsights.analyzers.audio import AudioAnalyzer
+from musinsights.analyzers.base import AnalysisResult, BaseAnalyzer, SongFeatures
 
 __all__ = [
     "AnalysisResult",

--- a/src/musinsights/analyzers/audio.py
+++ b/src/musinsights/analyzers/audio.py
@@ -1,10 +1,10 @@
 """Audio analyzer using librosa for feature extraction."""
 
 import asyncio
+from collections.abc import Sequence
 from concurrent.futures import ProcessPoolExecutor
-from functools import partial
 from pathlib import Path
-from typing import Any, Sequence
+from typing import Any
 
 import numpy as np
 from sqlalchemy.ext.asyncio import AsyncSession

--- a/src/musinsights/analyzers/base.py
+++ b/src/musinsights/analyzers/base.py
@@ -1,8 +1,9 @@
 """Base classes for audio analyzers."""
 
 from abc import ABC, abstractmethod
+from collections.abc import Sequence
 from dataclasses import dataclass, field
-from typing import Any, Sequence
+from typing import Any
 
 from sqlalchemy.ext.asyncio import AsyncSession
 

--- a/src/musinsights/cli.py
+++ b/src/musinsights/cli.py
@@ -248,6 +248,122 @@ async def enrich_mbid(limit: int | None, force: bool) -> None:
         await close_engine()
 
 
+@cli.group()
+def listenbrainz() -> None:
+    """ListenBrainz integration commands."""
+    pass
+
+
+@listenbrainz.command("auth")
+async def listenbrainz_auth() -> None:
+    """Validate ListenBrainz authentication."""
+    from musinsights.services.listenbrainz import ListenBrainzService
+
+    if not settings.listenbrainz_token:
+        console.print(
+            "[red]ListenBrainz token not configured.[/red]\n"
+            "Set MUSINSIGHTS_LISTENBRAINZ_TOKEN environment variable.\n"
+            "Get your token at: https://listenbrainz.org/settings/"
+        )
+        raise click.Abort()
+
+    try:
+        service = ListenBrainzService()
+        valid, result = await service.validate_token()
+
+        if valid:
+            console.print(f"[green]Token valid![/green] Authenticated as: {result}")
+        else:
+            console.print(f"[red]Token invalid:[/red] {result}")
+            raise click.Abort()
+
+    except ValueError as e:
+        console.print(f"[red]Error:[/red] {e}")
+        raise click.Abort()
+
+
+@listenbrainz.command("submit")
+@click.argument("song_id", required=False)
+@click.option("--all", "submit_all", is_flag=True, help="Submit all songs as historical listens")
+@click.option("--now-playing", is_flag=True, help="Submit as currently playing (not a listen)")
+async def listenbrainz_submit(
+    song_id: str | None, submit_all: bool, now_playing: bool
+) -> None:
+    """Submit listen(s) to ListenBrainz.
+
+    SONG_ID is the UUID of a song to submit. Use --all to submit all songs.
+    """
+    from musinsights.db import SongRepository
+    from musinsights.services.listenbrainz import (
+        ListenBrainzService,
+        create_listen_from_song,
+    )
+
+    if not song_id and not submit_all:
+        console.print("[red]Provide a SONG_ID or use --all flag[/red]")
+        raise click.Abort()
+
+    if not settings.listenbrainz_token:
+        console.print(
+            "[red]ListenBrainz token not configured.[/red]\n"
+            "Set MUSINSIGHTS_LISTENBRAINZ_TOKEN environment variable."
+        )
+        raise click.Abort()
+
+    try:
+        service = ListenBrainzService()
+
+        async with get_session() as session:
+            repo = SongRepository(session)
+
+            if submit_all:
+                songs = list(await repo.get_all())
+                if not songs:
+                    console.print("[yellow]No songs in library.[/yellow]")
+                    return
+
+                console.print(f"[blue]Submitting {len(songs)} songs to ListenBrainz...[/blue]")
+
+                listens = [create_listen_from_song(song) for song in songs]
+                result = await service.submit_listens(listens)
+
+                if result.success:
+                    console.print(f"[green]{result.message}[/green]")
+                else:
+                    console.print(f"[red]{result.message}[/red]")
+                    raise click.Abort()
+
+            else:
+                song = await repo.get_by_id(song_id)  # type: ignore
+                if not song:
+                    console.print(f"[red]Song not found:[/red] {song_id}")
+                    raise click.Abort()
+
+                listen = create_listen_from_song(song)
+
+                if now_playing:
+                    result = await service.submit_now_playing(listen)
+                else:
+                    result = await service.submit_listen(listen)
+
+                if result.success:
+                    console.print(
+                        f"[green]\u2713[/green] Submitted: {song.artist} - {song.title}"
+                    )
+                else:
+                    console.print(f"[red]{result.message}[/red]")
+                    raise click.Abort()
+
+    except ValueError as e:
+        console.print(f"[red]Error:[/red] {e}")
+        raise click.Abort()
+    except Exception as e:
+        console.print(f"[red]Error submitting listen:[/red] {e}")
+        raise click.Abort()
+    finally:
+        await close_engine()
+
+
 @cli.command()
 async def stats() -> None:
     """Show statistics about the music library."""

--- a/src/musinsights/cli.py
+++ b/src/musinsights/cli.py
@@ -1,8 +1,6 @@
 """CLI interface for MusInsights."""
 
-import asyncio
 from pathlib import Path
-from typing import Optional
 
 import asyncclick as click
 from rich.console import Console
@@ -108,7 +106,7 @@ def analyze() -> None:
 @analyze.command("all")
 @click.option("--force", "-f", is_flag=True, help="Re-analyze all songs, even if already analyzed")
 @click.option("--limit", "-l", type=int, help="Maximum number of songs to analyze")
-async def analyze_all(force: bool, limit: Optional[int]) -> None:
+async def analyze_all(force: bool, limit: int | None) -> None:
     """Analyze all unanalyzed songs."""
     from musinsights.analyzers.audio import AudioAnalyzer
     from musinsights.db import SongRepository
@@ -185,6 +183,71 @@ async def export_csv(output: Path) -> None:
         await close_engine()
 
 
+@cli.group()
+def enrich() -> None:
+    """Enrich songs with external metadata."""
+    pass
+
+
+@enrich.command("mbid")
+@click.option("--limit", "-l", type=int, help="Maximum number of songs to process")
+@click.option("--force", "-f", is_flag=True, help="Re-lookup even if MBID already exists")
+async def enrich_mbid(limit: int | None, force: bool) -> None:
+    """Enrich songs with MusicBrainz IDs."""
+    from musinsights.db import SongRepository
+    from musinsights.services.musicbrainz import MusicBrainzService
+
+    try:
+        async with get_session() as session:
+            repo = SongRepository(session)
+            mb_service = MusicBrainzService()
+
+            if force:
+                songs = await repo.get_all(limit=limit)
+            else:
+                songs = await repo.get_without_mbid(limit=limit)
+
+            if not songs:
+                console.print("[yellow]No songs to enrich.[/yellow]")
+                return
+
+            console.print(f"[blue]Looking up MusicBrainz IDs for {len(songs)} songs...[/blue]")
+            console.print("[dim]Rate limited to 1 request/second[/dim]")
+
+            found = 0
+            not_found = 0
+
+            for song in songs:
+                match = await mb_service.lookup_recording(
+                    title=song.title,
+                    artist=song.artist,
+                    duration_ms=song.duration_ms,
+                )
+
+                if match:
+                    song.musicbrainz_recording_id = match.recording_id
+                    song.musicbrainz_artist_id = match.artist_id
+                    await repo.update(song)
+                    found += 1
+                    console.print(
+                        f"  [green]\u2713[/green] {song.artist} - {song.title} "
+                        f"[dim](score: {match.score})[/dim]"
+                    )
+                else:
+                    not_found += 1
+                    console.print(f"  [yellow]\u2717[/yellow] {song.artist} - {song.title}")
+
+            console.print(f"\n[green]Found MBIDs for {found} songs[/green]")
+            if not_found > 0:
+                console.print(f"[yellow]Could not find MBIDs for {not_found} songs[/yellow]")
+
+    except Exception as e:
+        console.print(f"[red]Error during enrichment:[/red] {e}")
+        raise click.Abort()
+    finally:
+        await close_engine()
+
+
 @cli.command()
 async def stats() -> None:
     """Show statistics about the music library."""
@@ -198,6 +261,7 @@ async def stats() -> None:
             local = await repo.count(source="local")
             spotify = await repo.count(source="spotify")
             unanalyzed = len(await repo.get_unanalyzed())
+            without_mbid = len(await repo.get_without_mbid())
 
             table = Table(title="Library Statistics")
             table.add_column("Metric", style="cyan")
@@ -208,6 +272,7 @@ async def stats() -> None:
             table.add_row("From Spotify", str(spotify))
             table.add_row("Unanalyzed", str(unanalyzed))
             table.add_row("Analyzed", str(total - unanalyzed))
+            table.add_row("With MusicBrainz ID", str(total - without_mbid))
 
             console.print(table)
 

--- a/src/musinsights/config.py
+++ b/src/musinsights/config.py
@@ -41,6 +41,16 @@ class Settings(BaseSettings):
         description="Spotify OAuth redirect URI",
     )
 
+    # ListenBrainz settings (optional)
+    listenbrainz_token: str | None = Field(
+        default=None,
+        description="ListenBrainz user token for API access",
+    )
+    listenbrainz_username: str | None = Field(
+        default=None,
+        description="ListenBrainz username for fetching history",
+    )
+
     # Analysis settings
     analysis_workers: int = Field(
         default=4,

--- a/src/musinsights/config.py
+++ b/src/musinsights/config.py
@@ -1,7 +1,6 @@
 """Configuration management for MusInsights."""
 
 from pathlib import Path
-from typing import Optional
 
 from pydantic import Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
@@ -29,11 +28,11 @@ class Settings(BaseSettings):
     )
 
     # Spotify settings (optional)
-    spotify_client_id: Optional[str] = Field(
+    spotify_client_id: str | None = Field(
         default=None,
         description="Spotify API client ID",
     )
-    spotify_client_secret: Optional[str] = Field(
+    spotify_client_secret: str | None = Field(
         default=None,
         description="Spotify API client secret",
     )

--- a/src/musinsights/db/engine.py
+++ b/src/musinsights/db/engine.py
@@ -1,7 +1,7 @@
 """Database engine and session management."""
 
+from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
-from typing import AsyncGenerator
 
 from sqlalchemy.ext.asyncio import (
     AsyncEngine,

--- a/src/musinsights/db/models.py
+++ b/src/musinsights/db/models.py
@@ -30,12 +30,20 @@ class Song(Base):
     )
     title: Mapped[str] = mapped_column(Text, nullable=False, index=True)
     artist: Mapped[str] = mapped_column(Text, nullable=False, index=True)
-    album: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
-    duration_ms: Mapped[Optional[int]] = mapped_column(Integer, nullable=True)
-    file_path: Mapped[Optional[str]] = mapped_column(Text, nullable=True, unique=True)
-    file_hash: Mapped[Optional[str]] = mapped_column(String(64), nullable=True, index=True)
+    album: Mapped[str | None] = mapped_column(Text, nullable=True)
+    duration_ms: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    file_path: Mapped[str | None] = mapped_column(Text, nullable=True, unique=True)
+    file_hash: Mapped[str | None] = mapped_column(String(64), nullable=True, index=True)
     source: Mapped[str] = mapped_column(String(50), nullable=False, index=True)
-    external_ids: Mapped[Optional[dict[str, Any]]] = mapped_column(JSON, nullable=True)
+    external_ids: Mapped[dict[str, Any] | None] = mapped_column(JSON, nullable=True)
+
+    # MusicBrainz identifiers (universal join keys for external services)
+    musicbrainz_recording_id: Mapped[str | None] = mapped_column(
+        String(36), nullable=True, index=True
+    )
+    musicbrainz_artist_id: Mapped[str | None] = mapped_column(
+        String(36), nullable=True, index=True
+    )
     created_at: Mapped[datetime] = mapped_column(default=datetime.utcnow)
     updated_at: Mapped[datetime] = mapped_column(
         default=datetime.utcnow, onupdate=datetime.utcnow
@@ -64,17 +72,17 @@ class AudioFeatures(Base):
     song_id: Mapped[str] = mapped_column(
         String(36), ForeignKey("songs.id", ondelete="CASCADE"), primary_key=True
     )
-    tempo: Mapped[Optional[float]] = mapped_column(Float, nullable=True)
-    time_signature: Mapped[Optional[int]] = mapped_column(Integer, nullable=True)
-    key: Mapped[Optional[int]] = mapped_column(Integer, nullable=True)  # 0-11 for C to B
-    mode: Mapped[Optional[int]] = mapped_column(Integer, nullable=True)  # 1=major, 0=minor
-    loudness: Mapped[Optional[float]] = mapped_column(Float, nullable=True)  # dB
-    energy: Mapped[Optional[float]] = mapped_column(Float, nullable=True)  # 0-1
-    danceability: Mapped[Optional[float]] = mapped_column(Float, nullable=True)  # 0-1
-    valence: Mapped[Optional[float]] = mapped_column(Float, nullable=True)  # 0-1
-    acousticness: Mapped[Optional[float]] = mapped_column(Float, nullable=True)  # 0-1
-    instrumentalness: Mapped[Optional[float]] = mapped_column(Float, nullable=True)  # 0-1
-    speechiness: Mapped[Optional[float]] = mapped_column(Float, nullable=True)  # 0-1
+    tempo: Mapped[float | None] = mapped_column(Float, nullable=True)
+    time_signature: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    key: Mapped[int | None] = mapped_column(Integer, nullable=True)  # 0-11 for C to B
+    mode: Mapped[int | None] = mapped_column(Integer, nullable=True)  # 1=major, 0=minor
+    loudness: Mapped[float | None] = mapped_column(Float, nullable=True)  # dB
+    energy: Mapped[float | None] = mapped_column(Float, nullable=True)  # 0-1
+    danceability: Mapped[float | None] = mapped_column(Float, nullable=True)  # 0-1
+    valence: Mapped[float | None] = mapped_column(Float, nullable=True)  # 0-1
+    acousticness: Mapped[float | None] = mapped_column(Float, nullable=True)  # 0-1
+    instrumentalness: Mapped[float | None] = mapped_column(Float, nullable=True)  # 0-1
+    speechiness: Mapped[float | None] = mapped_column(Float, nullable=True)  # 0-1
     analyzed_at: Mapped[datetime] = mapped_column(default=datetime.utcnow)
 
     # Relationship
@@ -92,13 +100,13 @@ class SpectralFeatures(Base):
     song_id: Mapped[str] = mapped_column(
         String(36), ForeignKey("songs.id", ondelete="CASCADE"), primary_key=True
     )
-    mfcc_mean: Mapped[Optional[bytes]] = mapped_column(LargeBinary, nullable=True)
-    mfcc_std: Mapped[Optional[bytes]] = mapped_column(LargeBinary, nullable=True)
-    spectral_centroid: Mapped[Optional[float]] = mapped_column(Float, nullable=True)
-    spectral_rolloff: Mapped[Optional[float]] = mapped_column(Float, nullable=True)
-    spectral_contrast: Mapped[Optional[bytes]] = mapped_column(LargeBinary, nullable=True)
-    chroma_mean: Mapped[Optional[bytes]] = mapped_column(LargeBinary, nullable=True)
-    zero_crossing_rate: Mapped[Optional[float]] = mapped_column(Float, nullable=True)
+    mfcc_mean: Mapped[bytes | None] = mapped_column(LargeBinary, nullable=True)
+    mfcc_std: Mapped[bytes | None] = mapped_column(LargeBinary, nullable=True)
+    spectral_centroid: Mapped[float | None] = mapped_column(Float, nullable=True)
+    spectral_rolloff: Mapped[float | None] = mapped_column(Float, nullable=True)
+    spectral_contrast: Mapped[bytes | None] = mapped_column(LargeBinary, nullable=True)
+    chroma_mean: Mapped[bytes | None] = mapped_column(LargeBinary, nullable=True)
+    zero_crossing_rate: Mapped[float | None] = mapped_column(Float, nullable=True)
     analyzed_at: Mapped[datetime] = mapped_column(default=datetime.utcnow)
 
     # Relationship
@@ -121,7 +129,7 @@ class ListeningHistory(Base):
     )
     played_at: Mapped[datetime] = mapped_column(nullable=False, index=True)
     source: Mapped[str] = mapped_column(String(50), nullable=False)
-    context: Mapped[Optional[dict[str, Any]]] = mapped_column(JSON, nullable=True)
+    context: Mapped[dict[str, Any] | None] = mapped_column(JSON, nullable=True)
 
     # Relationship
     song: Mapped["Song"] = relationship(back_populates="listening_history")

--- a/src/musinsights/db/repository.py
+++ b/src/musinsights/db/repository.py
@@ -1,6 +1,6 @@
 """Repository pattern for database operations."""
 
-from typing import Optional, Sequence
+from collections.abc import Sequence
 
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -33,7 +33,7 @@ class SongRepository:
         await self.session.flush()
         return song
 
-    async def get_by_id(self, song_id: str, load_features: bool = False) -> Optional[Song]:
+    async def get_by_id(self, song_id: str, load_features: bool = False) -> Song | None:
         """Get a song by its ID.
 
         Args:
@@ -52,7 +52,7 @@ class SongRepository:
         result = await self.session.execute(stmt)
         return result.scalar_one_or_none()
 
-    async def get_by_file_path(self, file_path: str) -> Optional[Song]:
+    async def get_by_file_path(self, file_path: str) -> Song | None:
         """Get a song by its file path.
 
         Args:
@@ -65,7 +65,7 @@ class SongRepository:
         result = await self.session.execute(stmt)
         return result.scalar_one_or_none()
 
-    async def get_by_file_hash(self, file_hash: str) -> Optional[Song]:
+    async def get_by_file_hash(self, file_hash: str) -> Song | None:
         """Get a song by its file hash.
 
         Args:
@@ -80,8 +80,8 @@ class SongRepository:
 
     async def get_all(
         self,
-        source: Optional[str] = None,
-        limit: Optional[int] = None,
+        source: str | None = None,
+        limit: int | None = None,
         offset: int = 0,
     ) -> Sequence[Song]:
         """Get all songs, optionally filtered by source.
@@ -104,7 +104,7 @@ class SongRepository:
         result = await self.session.execute(stmt)
         return result.scalars().all()
 
-    async def get_unanalyzed(self, limit: Optional[int] = None) -> Sequence[Song]:
+    async def get_unanalyzed(self, limit: int | None = None) -> Sequence[Song]:
         """Get songs that haven't been analyzed yet.
 
         Args:
@@ -151,7 +151,7 @@ class SongRepository:
             return True
         return False
 
-    async def count(self, source: Optional[str] = None) -> int:
+    async def count(self, source: str | None = None) -> int:
         """Count total songs, optionally filtered by source.
 
         Args:
@@ -168,6 +168,25 @@ class SongRepository:
         result = await self.session.execute(stmt)
         return result.scalar_one()
 
+    async def get_without_mbid(self, limit: int | None = None) -> Sequence[Song]:
+        """Get songs without MusicBrainz recording IDs.
+
+        Args:
+            limit: Maximum number of songs to return.
+
+        Returns:
+            List of Song objects without MusicBrainz IDs.
+        """
+        stmt = (
+            select(Song)
+            .where(Song.musicbrainz_recording_id.is_(None))
+            .order_by(Song.created_at.desc())
+        )
+        if limit:
+            stmt = stmt.limit(limit)
+        result = await self.session.execute(stmt)
+        return result.scalars().all()
+
 
 class AudioFeaturesRepository:
     """Repository for AudioFeatures database operations."""
@@ -181,7 +200,7 @@ class AudioFeaturesRepository:
         await self.session.flush()
         return features
 
-    async def get_by_song_id(self, song_id: str) -> Optional[AudioFeatures]:
+    async def get_by_song_id(self, song_id: str) -> AudioFeatures | None:
         """Get audio features for a specific song."""
         stmt = select(AudioFeatures).where(AudioFeatures.song_id == song_id)
         result = await self.session.execute(stmt)
@@ -215,7 +234,7 @@ class ListeningHistoryRepository:
     async def get_by_song_id(
         self,
         song_id: str,
-        limit: Optional[int] = None,
+        limit: int | None = None,
     ) -> Sequence[ListeningHistory]:
         """Get listening history for a specific song."""
         stmt = (

--- a/src/musinsights/exporters/formats.py
+++ b/src/musinsights/exporters/formats.py
@@ -1,9 +1,10 @@
 """Export functions for various data formats."""
 
 import json
+from collections.abc import Sequence
 from datetime import datetime
 from pathlib import Path
-from typing import Any, Sequence
+from typing import Any
 
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession

--- a/src/musinsights/ingestors/local_files.py
+++ b/src/musinsights/ingestors/local_files.py
@@ -2,8 +2,9 @@
 
 import asyncio
 import hashlib
+from collections.abc import AsyncIterator
 from pathlib import Path
-from typing import Any, AsyncIterator
+from typing import Any
 
 import aiofiles
 from mutagen import File as MutagenFile

--- a/src/musinsights/pipeline/runner.py
+++ b/src/musinsights/pipeline/runner.py
@@ -1,12 +1,13 @@
 """Pipeline execution engine."""
 
 import asyncio
+from collections.abc import Callable
 from dataclasses import dataclass, field
 from datetime import datetime
-from typing import Any, Callable
+from typing import Any
 
 from rich.console import Console
-from rich.progress import BarColumn, Progress, SpinnerColumn, TaskID, TextColumn
+from rich.progress import BarColumn, Progress, SpinnerColumn, TextColumn
 
 from musinsights.pipeline.stages import Stage, StageResult, StageStatus
 

--- a/src/musinsights/services/__init__.py
+++ b/src/musinsights/services/__init__.py
@@ -1,0 +1,5 @@
+"""External service integrations."""
+
+from musinsights.services.musicbrainz import MusicBrainzService
+
+__all__ = ["MusicBrainzService"]

--- a/src/musinsights/services/__init__.py
+++ b/src/musinsights/services/__init__.py
@@ -1,5 +1,17 @@
 """External service integrations."""
 
+from musinsights.services.listenbrainz import (
+    Listen,
+    ListenBrainzService,
+    SubmitResult,
+    create_listen_from_song,
+)
 from musinsights.services.musicbrainz import MusicBrainzService
 
-__all__ = ["MusicBrainzService"]
+__all__ = [
+    "Listen",
+    "ListenBrainzService",
+    "MusicBrainzService",
+    "SubmitResult",
+    "create_listen_from_song",
+]

--- a/src/musinsights/services/listenbrainz.py
+++ b/src/musinsights/services/listenbrainz.py
@@ -1,0 +1,232 @@
+"""ListenBrainz API integration for scrobbling and listening history."""
+
+from dataclasses import dataclass
+from datetime import datetime
+
+import httpx
+
+from musinsights.config import settings
+
+# ListenBrainz API base URL
+API_BASE = "https://api.listenbrainz.org"
+
+
+@dataclass
+class Listen:
+    """A single listen event."""
+
+    track_name: str
+    artist_name: str
+    listened_at: int  # Unix timestamp
+    release_name: str | None = None
+    recording_mbid: str | None = None
+    artist_mbid: str | None = None
+    duration_ms: int | None = None
+
+
+@dataclass
+class SubmitResult:
+    """Result of a listen submission."""
+
+    success: bool
+    message: str
+
+
+class ListenBrainzService:
+    """Service for interacting with the ListenBrainz API."""
+
+    def __init__(self, token: str | None = None) -> None:
+        """Initialize the service.
+
+        Args:
+            token: ListenBrainz user token. If not provided, uses settings.
+        """
+        self.token = token or settings.listenbrainz_token
+        if not self.token:
+            raise ValueError(
+                "ListenBrainz token required. Set MUSINSIGHTS_LISTENBRAINZ_TOKEN "
+                "environment variable or pass token directly."
+            )
+
+    def _get_headers(self) -> dict[str, str]:
+        """Get authorization headers for API requests."""
+        return {
+            "Authorization": f"Token {self.token}",
+            "Content-Type": "application/json",
+        }
+
+    async def submit_listen(self, listen: Listen) -> SubmitResult:
+        """Submit a single listen to ListenBrainz.
+
+        Args:
+            listen: The listen event to submit.
+
+        Returns:
+            SubmitResult indicating success or failure.
+        """
+        payload = self._build_listen_payload([listen], "single")
+        return await self._submit_payload(payload)
+
+    async def submit_listens(self, listens: list[Listen]) -> SubmitResult:
+        """Submit multiple listens to ListenBrainz.
+
+        Args:
+            listens: List of listen events to submit (max 1000).
+
+        Returns:
+            SubmitResult indicating success or failure.
+        """
+        if len(listens) > 1000:
+            return SubmitResult(
+                success=False,
+                message="Cannot submit more than 1000 listens at once",
+            )
+
+        payload = self._build_listen_payload(listens, "import")
+        return await self._submit_payload(payload)
+
+    async def submit_now_playing(self, listen: Listen) -> SubmitResult:
+        """Submit a "now playing" notification to ListenBrainz.
+
+        Args:
+            listen: The currently playing track.
+
+        Returns:
+            SubmitResult indicating success or failure.
+        """
+        payload = self._build_listen_payload([listen], "playing_now")
+        return await self._submit_payload(payload)
+
+    def _build_listen_payload(
+        self, listens: list[Listen], listen_type: str
+    ) -> dict:
+        """Build the JSON payload for a listen submission.
+
+        Args:
+            listens: List of listens to include.
+            listen_type: One of "single", "import", or "playing_now".
+
+        Returns:
+            JSON-serializable payload dict.
+        """
+        payload_listens = []
+        for listen in listens:
+            track_metadata: dict = {
+                "track_name": listen.track_name,
+                "artist_name": listen.artist_name,
+            }
+
+            if listen.release_name:
+                track_metadata["release_name"] = listen.release_name
+
+            # Add additional info if available
+            additional_info: dict = {}
+            if listen.recording_mbid:
+                additional_info["recording_mbid"] = listen.recording_mbid
+            if listen.artist_mbid:
+                additional_info["artist_mbids"] = [listen.artist_mbid]
+            if listen.duration_ms:
+                additional_info["duration_ms"] = listen.duration_ms
+
+            if additional_info:
+                track_metadata["additional_info"] = additional_info
+
+            listen_data: dict = {"track_metadata": track_metadata}
+
+            # Only add listened_at for non-playing_now submissions
+            if listen_type != "playing_now":
+                listen_data["listened_at"] = listen.listened_at
+
+            payload_listens.append(listen_data)
+
+        return {
+            "listen_type": listen_type,
+            "payload": payload_listens,
+        }
+
+    async def _submit_payload(self, payload: dict) -> SubmitResult:
+        """Submit a payload to the ListenBrainz API.
+
+        Args:
+            payload: The JSON payload to submit.
+
+        Returns:
+            SubmitResult indicating success or failure.
+        """
+        async with httpx.AsyncClient() as client:
+            try:
+                response = await client.post(
+                    f"{API_BASE}/1/submit-listens",
+                    headers=self._get_headers(),
+                    json=payload,
+                    timeout=30.0,
+                )
+
+                if response.status_code == 200:
+                    return SubmitResult(success=True, message="Listen(s) submitted successfully")
+
+                # Handle error responses
+                try:
+                    error_data = response.json()
+                    error_msg = error_data.get("error", response.text)
+                except Exception:
+                    error_msg = response.text
+
+                return SubmitResult(success=False, message=f"API error: {error_msg}")
+
+            except httpx.TimeoutException:
+                return SubmitResult(success=False, message="Request timed out")
+            except httpx.RequestError as e:
+                return SubmitResult(success=False, message=f"Request failed: {e}")
+
+    async def validate_token(self) -> tuple[bool, str]:
+        """Validate the user token with ListenBrainz.
+
+        Returns:
+            Tuple of (is_valid, username or error message).
+        """
+        async with httpx.AsyncClient() as client:
+            try:
+                response = await client.get(
+                    f"{API_BASE}/1/validate-token",
+                    headers=self._get_headers(),
+                    timeout=10.0,
+                )
+
+                if response.status_code == 200:
+                    data = response.json()
+                    if data.get("valid"):
+                        return True, data.get("user_name", "unknown")
+                    return False, "Token is invalid"
+
+                return False, f"API returned status {response.status_code}"
+
+            except httpx.RequestError as e:
+                return False, f"Request failed: {e}"
+
+
+def create_listen_from_song(
+    song: "Song",  # type: ignore  # noqa: F821
+    listened_at: datetime | None = None,
+) -> Listen:
+    """Create a Listen object from a Song model.
+
+    Args:
+        song: The Song object to create a listen from.
+        listened_at: When the song was played. Defaults to now.
+
+    Returns:
+        A Listen object ready for submission.
+    """
+    if listened_at is None:
+        listened_at = datetime.utcnow()
+
+    return Listen(
+        track_name=song.title,
+        artist_name=song.artist,
+        listened_at=int(listened_at.timestamp()),
+        release_name=song.album,
+        recording_mbid=song.musicbrainz_recording_id,
+        artist_mbid=song.musicbrainz_artist_id,
+        duration_ms=song.duration_ms,
+    )

--- a/src/musinsights/services/musicbrainz.py
+++ b/src/musinsights/services/musicbrainz.py
@@ -1,0 +1,155 @@
+"""MusicBrainz API integration for metadata lookup."""
+
+import asyncio
+import time
+from dataclasses import dataclass
+
+import musicbrainzngs
+
+# Configure the MusicBrainz client
+musicbrainzngs.set_useragent(
+    "MusInsights",
+    "0.1.0",
+    "https://github.com/Finaris/musinsights",
+)
+
+
+@dataclass
+class MusicBrainzMatch:
+    """Result of a MusicBrainz lookup."""
+
+    recording_id: str
+    artist_id: str
+    title: str
+    artist: str
+    score: int  # Match confidence 0-100
+
+
+class MusicBrainzService:
+    """Service for looking up MusicBrainz IDs."""
+
+    # Rate limit: 1 request per second for unauthenticated requests
+    MIN_REQUEST_INTERVAL = 1.0
+
+    def __init__(self) -> None:
+        self._last_request_time: float = 0
+
+    async def _rate_limit(self) -> None:
+        """Ensure we don't exceed MusicBrainz rate limits."""
+        now = time.monotonic()
+        elapsed = now - self._last_request_time
+        if elapsed < self.MIN_REQUEST_INTERVAL:
+            await asyncio.sleep(self.MIN_REQUEST_INTERVAL - elapsed)
+        self._last_request_time = time.monotonic()
+
+    async def lookup_recording(
+        self,
+        title: str,
+        artist: str,
+        duration_ms: int | None = None,
+    ) -> MusicBrainzMatch | None:
+        """Look up a recording by title and artist.
+
+        Args:
+            title: The track title.
+            artist: The artist name.
+            duration_ms: Optional duration in milliseconds for better matching.
+
+        Returns:
+            MusicBrainzMatch if found with good confidence, None otherwise.
+        """
+        await self._rate_limit()
+
+        # Build search query
+        query = f'recording:"{title}" AND artist:"{artist}"'
+
+        try:
+            # Run the blocking API call in a thread pool
+            result = await asyncio.to_thread(
+                musicbrainzngs.search_recordings,
+                query=query,
+                limit=5,
+            )
+        except musicbrainzngs.WebServiceError:
+            # Log but don't crash on API errors
+            return None
+
+        recordings = result.get("recording-list", [])
+        if not recordings:
+            return None
+
+        # Find best match
+        best_match: MusicBrainzMatch | None = None
+        best_score = 0
+
+        for recording in recordings:
+            score = int(recording.get("ext:score", 0))
+
+            # Must have at least one artist credit
+            artist_credits = recording.get("artist-credit", [])
+            if not artist_credits:
+                continue
+
+            # Get first artist (primary artist)
+            first_credit = artist_credits[0]
+            if isinstance(first_credit, dict) and "artist" in first_credit:
+                artist_info = first_credit["artist"]
+                artist_id = artist_info.get("id")
+                artist_name = artist_info.get("name", "")
+            else:
+                continue
+
+            recording_id = recording.get("id")
+            recording_title = recording.get("title", "")
+
+            if not recording_id or not artist_id:
+                continue
+
+            # If duration provided, check it's within 5 seconds
+            if duration_ms is not None:
+                recording_length = recording.get("length")
+                if recording_length:
+                    diff = abs(int(recording_length) - duration_ms)
+                    if diff > 5000:  # More than 5 seconds difference
+                        score -= 20  # Penalize but don't disqualify
+
+            if score > best_score:
+                best_score = score
+                best_match = MusicBrainzMatch(
+                    recording_id=recording_id,
+                    artist_id=artist_id,
+                    title=recording_title,
+                    artist=artist_name,
+                    score=score,
+                )
+
+        # Only return if we have a reasonably confident match
+        if best_match and best_match.score >= 80:
+            return best_match
+
+        return None
+
+    async def lookup_artist(self, artist_name: str) -> str | None:
+        """Look up an artist's MusicBrainz ID by name.
+
+        Args:
+            artist_name: The artist name to search for.
+
+        Returns:
+            MusicBrainz artist ID if found, None otherwise.
+        """
+        await self._rate_limit()
+
+        try:
+            result = await asyncio.to_thread(
+                musicbrainzngs.search_artists,
+                query=f'artist:"{artist_name}"',
+                limit=1,
+            )
+        except musicbrainzngs.WebServiceError:
+            return None
+
+        artists = result.get("artist-list", [])
+        if artists:
+            return artists[0].get("id")
+        return None

--- a/uv.lock
+++ b/uv.lock
@@ -660,6 +660,15 @@ wheels = [
 ]
 
 [[package]]
+name = "musicbrainzngs"
+version = "0.7.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0a/67/3e74ae93d90ceeba72ed1a266dd3ca9abd625f315f0afd35f9b034acedd1/musicbrainzngs-0.7.1.tar.gz", hash = "sha256:ab1c0100fd0b305852e65f2ed4113c6de12e68afd55186987b8ed97e0f98e627", size = 117469, upload-time = "2020-01-11T17:38:47.581Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6d/fd/cef7b2580436910ccd2f8d3deec0f3c81743e15c0eb5b97dde3fbf33c0c8/musicbrainzngs-0.7.1-py2.py3-none-any.whl", hash = "sha256:e841a8f975104c0a72290b09f59326050194081a5ae62ee512f41915090e1a10", size = 25289, upload-time = "2020-01-11T17:38:45.469Z" },
+]
+
+[[package]]
 name = "musinsights"
 version = "0.1.0"
 source = { editable = "." }
@@ -670,6 +679,7 @@ dependencies = [
     { name = "asyncclick" },
     { name = "click" },
     { name = "librosa" },
+    { name = "musicbrainzngs" },
     { name = "mutagen" },
     { name = "numpy" },
     { name = "pydantic" },
@@ -702,6 +712,7 @@ requires-dist = [
     { name = "click", specifier = ">=8.1" },
     { name = "duckdb", marker = "extra == 'analysis'", specifier = ">=0.9" },
     { name = "librosa", specifier = ">=0.10" },
+    { name = "musicbrainzngs", specifier = ">=0.7" },
     { name = "mutagen", specifier = ">=1.47" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.8" },
     { name = "numpy", specifier = ">=1.26" },

--- a/uv.lock
+++ b/uv.lock
@@ -52,6 +52,19 @@ wheels = [
 ]
 
 [[package]]
+name = "anyio"
+version = "4.13.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "idna" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/19/14/2c5dd9f512b66549ae92767a9c7b330ae88e1932ca57876909410251fe13/anyio-4.13.0.tar.gz", hash = "sha256:334b70e641fd2221c1505b3890c69882fe4a2df910cba14d97019b90b24439dc", size = 231622, upload-time = "2026-03-24T12:59:09.671Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/da/42/e921fccf5015463e32a3cf6ee7f980a6ed0f395ceeaa45060b61d86486c2/anyio-4.13.0-py3-none-any.whl", hash = "sha256:08b310f9e24a9594186fd75b4f73f4a4152069e3853f1ed8bfbf58369f4ad708", size = 114353, upload-time = "2026-03-24T12:59:08.246Z" },
+]
+
+[[package]]
 name = "async-timeout"
 version = "5.0.1"
 source = { registry = "https://pypi.org/simple" }
@@ -408,6 +421,43 @@ wheels = [
 ]
 
 [[package]]
+name = "h11"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
+]
+
+[[package]]
+name = "httpcore"
+version = "1.0.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484, upload-time = "2025-04-24T22:06:22.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55", size = 78784, upload-time = "2025-04-24T22:06:20.566Z" },
+]
+
+[[package]]
+name = "httpx"
+version = "0.28.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "certifi" },
+    { name = "httpcore" },
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
+]
+
+[[package]]
 name = "idna"
 version = "3.11"
 source = { registry = "https://pypi.org/simple" }
@@ -678,6 +728,7 @@ dependencies = [
     { name = "alembic" },
     { name = "asyncclick" },
     { name = "click" },
+    { name = "httpx" },
     { name = "librosa" },
     { name = "musicbrainzngs" },
     { name = "mutagen" },
@@ -711,6 +762,7 @@ requires-dist = [
     { name = "asyncclick", specifier = ">=8.1" },
     { name = "click", specifier = ">=8.1" },
     { name = "duckdb", marker = "extra == 'analysis'", specifier = ">=0.9" },
+    { name = "httpx", specifier = ">=0.27" },
     { name = "librosa", specifier = ">=0.10" },
     { name = "musicbrainzngs", specifier = ">=0.7" },
     { name = "mutagen", specifier = ">=1.47" },


### PR DESCRIPTION
## Summary
- Add `ListenBrainzService` for API interactions (submit listens, validate token)
- Add CLI commands for ListenBrainz integration:
  - `musinsights listenbrainz auth` - validate token
  - `musinsights listenbrainz submit <song_id>` - submit single listen
  - `musinsights listenbrainz submit --all` - bulk import all songs
  - `musinsights listenbrainz submit --now-playing` - "now playing" notification
- Include MusicBrainz IDs in submissions when available for accurate matching
- Add `httpx` for async HTTP requests

## Configuration
Set `MUSINSIGHTS_LISTENBRAINZ_TOKEN` environment variable with your user token from https://listenbrainz.org/settings/

## Test plan
- [x] `uv run musinsights listenbrainz auth` validates token (shows error without token)
- [x] `uv run musinsights listenbrainz submit --help` shows options
- [x] All existing tests pass

## Dependencies
- Depends on #14 (MusicBrainz ID support) - included in this branch

Closes #3

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)